### PR TITLE
package for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ sudo curl -Lo /usr/local/bin/$ http://git.io/N8t4Bg
 sudo chmod +x /usr/local/bin/$
 ```
 
+Or to install using [`npm`](https://www.npmjs.com/):
+
+```
+npm install -g dollar-sign
+```
+
 ## Usage
 
 Use the dollar sign or don't use the dollar sign – it doesn't matter at all.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "dollar-sign",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dollar-sign",
+  "version": "0.0.0",
+  "description": "$: command not found",
+  "bin": {
+    "$": "./$"
+  },
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/fraction/dollar-sign.git"
+  },
+  "keywords": [
+    "sh",
+    "shell",
+    "bash"
+  ],
+  "author": "Fraction LLC",
+  "license": "0BSD",
+  "bugs": {
+    "url": "https://github.com/fraction/dollar-sign/issues"
+  },
+  "homepage": "https://github.com/fraction/dollar-sign#readme"
+}


### PR DESCRIPTION
hi @christianbundy, i noticed this wee shell script, what a great idea!

i packaged the script for publishing to npm, in case that was something you were into. i tested it locally with `npm link --local`, it seems to be okay with the `bin` name being `$`.

if merged, can publish with:

```
npm version major
git push origin master --tags
npm publish
```

cheers! :smiley_cat: